### PR TITLE
Fix/when api reach the rate limit retry after 60 seconds.

### DIFF
--- a/agent/file.py
+++ b/agent/file.py
@@ -45,3 +45,5 @@ def get_file_content(message: m.Message) -> bytes | None:
     content_url: str | None = message.data.get("content_url")
     if content_url is not None:
         return _download_file(content_url)
+
+    return None

--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 import magic
+import tenacity
 from ostorlab.agent import agent, definitions as agent_definitions
 from ostorlab.agent.kb import kb
 from ostorlab.agent.message import message as msg
@@ -15,6 +16,9 @@ from agent import process_scans
 from agent import virustotal
 
 logger = logging.getLogger(__name__)
+
+NUMBER_RETRIES = 2
+WAIT_TIME = 60
 
 
 class VirusTotalAgent(
@@ -33,7 +37,7 @@ class VirusTotalAgent(
             agent_settings: Settings of running instance of the agent.
         """
         super().__init__(agent_definition, agent_settings)
-        self.api_key = self.args.get("api_key")
+        self.api_key = self.args.get("api_key", "")
         self.whitelist_types = self.args.get("whitelist_types", [])
 
     def process(self, message: msg.Message) -> None:
@@ -55,23 +59,46 @@ class VirusTotalAgent(
                 not in self.whitelist_types
             ):
                 return None
-            response = virustotal.scan_file_from_message(
-                file_content=file_content, api_key=self.api_key
-            )
-            self._process_response(response, message.data.get("path"))
+            self._scan_file(file_content, message.data.get("path"))
         else:
             targets = self._prepare_targets(message)
             for target in targets:
-                response = virustotal.scan_url_from_message(target, self.api_key)
-                self._process_response(response, target)
+                self._scan_url(target)
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(NUMBER_RETRIES),
+        wait=tenacity.wait_fixed(WAIT_TIME),
+        retry=tenacity.retry_if_exception_type(virustotal.VirusTotalApiError),
+        retry_error_callback=lambda retry_state: None,
+    )
+    def _scan_file(self, file_content: bytes, target: str | None) -> None:
+        """Send file to VirusTotal to be scanned, and process the response.
+        Args:
+            file_content: the content to be scanned.
+            target: target to scan.
+        """
+        if self.api_key is not None:
+            response = virustotal.scan_file_from_message(
+                file_content=file_content, api_key=self.api_key
+            )
+            self._process_response(response, target)
+
+    @tenacity.retry(
+        stop=tenacity.stop_after_attempt(NUMBER_RETRIES),
+        wait=tenacity.wait_fixed(WAIT_TIME),
+        retry=tenacity.retry_if_exception_type(virustotal.VirusTotalApiError),
+        retry_error_callback=lambda retry_state: None,
+    )
+    def _scan_url(self, target: str) -> None:
+        """Send url to VirusTotal to be scanned, and process the response.
+        Args:
+            target: target to scan.
+        """
+        response = virustotal.scan_url_from_message(target, self.api_key)
+        self._process_response(response, target)
 
     def _process_response(self, response: dict[str, Any], target: str | None) -> None:
-        try:
-            scans = virustotal.get_scans(response)
-        except virustotal.VirusTotalApiError:
-            logger.error("Virus Total API encountered some problems. Please try again.")
-            return None
-
+        scans = virustotal.get_scans(response)
         try:
             if scans is not None:
                 technical_detail = process_scans.get_technical_details(scans, target)

--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -37,7 +37,7 @@ class VirusTotalAgent(
             agent_settings: Settings of running instance of the agent.
         """
         super().__init__(agent_definition, agent_settings)
-        self.api_key = self.args.get("api_key", "")
+        self.api_key: str | None = self.args.get("api_key")
         self.whitelist_types = self.args.get("whitelist_types") or []
 
     def process(self, message: msg.Message) -> None:
@@ -94,8 +94,9 @@ class VirusTotalAgent(
         Args:
             target: target to scan.
         """
-        response = virustotal.scan_url_from_message(target, self.api_key)
-        self._process_response(response, target)
+        if self.api_key is not None:
+            response = virustotal.scan_url_from_message(target, self.api_key)
+            self._process_response(response, target)
 
     def _process_response(self, response: dict[str, Any], target: str | None) -> None:
         scans = virustotal.get_scans(response)

--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -66,7 +66,12 @@ class VirusTotalAgent(
                 self._process_response(response, target)
 
     def _process_response(self, response: dict[str, Any], target: str | None) -> None:
-        scans = virustotal.get_scans(response)
+        try:
+            scans = virustotal.get_scans(response)
+        except virustotal.VirusTotalApiError:
+            logger.error("Virus Total API encountered some problems. Please try again.")
+            return None
+
         try:
             if scans is not None:
                 technical_detail = process_scans.get_technical_details(scans, target)

--- a/agent/virustotal.py
+++ b/agent/virustotal.py
@@ -59,7 +59,6 @@ def get_scans(response: dict[str, Any]) -> dict[str, Any] | None:
         VirusTotalApiError: In case the API request encountered problems.
     """
     if response.get("response_code") == 204 and response.get("error") is not None:
-        logger.error("Exceeded the virustotal API rate limit.")
         raise VirusTotalApiError()
     elif response.get("response_code") == 0 or "results" not in response:
         raise VirusTotalApiError()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -143,7 +143,7 @@ def testVirusTotalAgent_whenVirusTotalApiReturnsInvalidResponse_agentShouldNotCr
 
     virustotal_agent.process(message)
 
-    assert get_scans_mocker.call_count == 2
+    assert get_scans_mocker.call_count == 1
 
 
 def testVirusTotalAgent_whenLinkReceived_virusTotalApiReturnsValidResponse(
@@ -326,20 +326,3 @@ def testVirusTotalAgent_whenWhiteListTypesAreNotProvided_shouldNotCrash(
     virustotal_agent.process(message)
 
     assert get_file_content_mock.call_count == 1
-
-
-def testVirusTotalAgent_whenVirusTotalReachesApiRateLimit_retryThenRaiseVirusTotalApiError(
-    mocker: plugin.MockerFixture,
-    virustotal_agent: virus_total_agent.VirusTotalAgent,
-    url_message: msg.Message,
-) -> None:
-    """Unit test for the lifecyle of the virustotal agent :
-    Case where the Virus Total public API reached the rate limit.
-    """
-    mocker.patch("time.sleep")
-    get_file_mock = mocker.patch(
-        "agent.virustotal.scan_url_from_message",
-        side_effect=virustotal_url_invalid_response,
-    )
-    virustotal_agent.process(url_message)
-    assert get_file_mock.call_count == 2

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -41,13 +41,6 @@ def virustotal_url_valid_response(url: str, timeout: int) -> dict[str, Any]:
     return response
 
 
-def virustotal_url_invalid_response(url: str, timeout: int) -> dict[str, Any]:
-    """Method for mocking the Virus Total public API invalid response."""
-    del url, timeout
-    response = {"response_code": 204, "error": "Reach the API limits"}
-    return response
-
-
 def testVirusTotalAgent_whenVirusTotalApiReturnsValidResponse_noRaiseVirusTotalApiError(
     mocker: plugin.MockerFixture,
     agent_mock: list[msg.Message],


### PR DESCRIPTION
- This PR purpose is to refactor the agent in which the API rate limit occurs to retry after 1 minute as the virustotal FAQ encourages that https://support.virustotal.com/hc/en-us/articles/115002119845-What-is-the-difference-between-the-public-API-and-the-private-API- 
- also this PR fix the unit tests that are slow by mocking `sleep`