### PR TITLE
Feat : Add CIDR Limit

### DIFF
--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -114,7 +114,7 @@ class VirusTotalAgent(
                 ip_network = ipaddress.ip_network(host)
             else:
                 version = message.data.get("version")
-                if version != 4 and version != 6:
+                if version not in (4, 6):
                     raise ValueError(f"Incorrect ip version {version}")
                 elif version == 4 and int(mask) < IPV4_CIDR_LIMIT:
                     raise ValueError(

--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -115,7 +115,7 @@ class VirusTotalAgent(
             else:
                 version = message.data.get("version")
                 if version not in (4, 6):
-                    raise ValueError(f"Incorrect ip version {version}")
+                    raise ValueError(f"Incorrect ip version {version}.")
                 elif version == 4 and int(mask) < IPV4_CIDR_LIMIT:
                     raise ValueError(
                         f"Subnet mask below {IPV4_CIDR_LIMIT} is not supported."

--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -114,11 +114,13 @@ class VirusTotalAgent(
                 ip_network = ipaddress.ip_network(host)
             else:
                 version = message.data.get("version")
-                if version == 4 and int(mask) < IPV4_CIDR_LIMIT:
+                if version != 4 and version != 6:
+                    raise ValueError(f"Incorrect ip version {version}")
+                elif version == 4 and int(mask) < IPV4_CIDR_LIMIT:
                     raise ValueError(
                         f"Subnet mask below {IPV4_CIDR_LIMIT} is not supported."
                     )
-                if version == 6 and int(mask) < IPV6_CIDR_LIMIT:
+                elif version == 6 and int(mask) < IPV6_CIDR_LIMIT:
                     raise ValueError(
                         f"Subnet mask below {IPV6_CIDR_LIMIT} is not supported."
                     )

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -1,6 +1,6 @@
 kind: Agent
 name: virustotal
-version: 0.2.0
+version: 0.2.1
 image: images/logo.png 
 description: |
   This repository is an implementation of the VirusTotal agent.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,3 +169,15 @@ def scan_message_ipv6_with_mask112() -> msg.Message:
         "version": 6,
     }
     return msg.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv_with_incorrect_version() -> msg.Message:
+    """Creates a message of type v3.asset.ip with an incorrect version."""
+    selector = "v3.asset.ip"
+    msg_data = {
+        "host": "0.0.0.0",
+        "mask": "32",
+        "version": 5,
+    }
+    return msg.Message.from_data(selector, data=msg_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,3 +129,43 @@ def message_without_path() -> msg.Message:
     selector = "v3.asset.file"
     msg_data = {"content": file_content}
     return msg.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv4_with_mask8() -> msg.Message:
+    """Creates a message of type v3.asset.ip.v4 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v4"
+    msg_data = {"host": "192.168.1.17", "mask": "8", "version": 4}
+    return msg.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv4_with_mask16() -> msg.Message:
+    """Creates a message of type v3.asset.ip.v4 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v4"
+    msg_data = {"host": "192.168.1.17", "mask": "16", "version": 4}
+    return msg.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv6_with_mask64() -> msg.Message:
+    """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v6"
+    msg_data = {
+        "host": "2001:db8:3333:4444:5555:6666:7777:8888",
+        "mask": "64",
+        "version": 6,
+    }
+    return msg.Message.from_data(selector, data=msg_data)
+
+
+@pytest.fixture()
+def scan_message_ipv6_with_mask112() -> msg.Message:
+    """Creates a message of type v3.asset.ip.v6 to be used by the agent for testing purposes."""
+    selector = "v3.asset.ip.v6"
+    msg_data = {
+        "host": "2001:db8:3333:4444:5555:6666:7777:8888",
+        "mask": "112",
+        "version": 6,
+    }
+    return msg.Message.from_data(selector, data=msg_data)

--- a/tests/virus_total_agent_test.py
+++ b/tests/virus_total_agent_test.py
@@ -6,6 +6,7 @@ import requests_mock as rq_mock
 
 from ostorlab.agent.message import message as msg
 from pytest_mock import plugin
+import pytest
 
 from agent import virus_total_agent
 from agent import virustotal
@@ -334,3 +335,61 @@ def testVirusTotalAgent_whenFileHasNoPath_shouldReportWithHash(
         "Analysis of the target `44d88612fea8a8f36de82e1278abb02f`:\n|Package|  Result  |  \n"
         "|-------|----------|  \n|Bkav   |_Safe_    |  \n|Elastic|_Malicous_|  \n"
     )
+
+
+def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
+    mocker: plugin.MockerFixture,
+    scan_message_ipv4_with_mask8: msg.Message,
+    virustotal_agent: virus_total_agent.VirusTotalAgent,
+) -> None:
+    """Test the CIDR Limit in case IPV4 and the Limit is reached."""
+    mocker.patch(
+        "agent.virustotal.scan_url_from_message",
+        return_value={},
+    )
+
+    with pytest.raises(ValueError, match="Subnet mask below 16 is not supported."):
+        virustotal_agent.process(scan_message_ipv4_with_mask8)
+
+
+def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+    mocker: plugin.MockerFixture,
+    scan_message_ipv4_with_mask16: msg.Message,
+    virustotal_agent: virus_total_agent.VirusTotalAgent,
+) -> None:
+    """Test the CIDR Limit in case IPV4 and the Limit is not reached."""
+    mocker.patch(
+        "agent.virustotal.scan_url_from_message",
+        return_value={},
+    )
+
+    virustotal_agent.process(scan_message_ipv4_with_mask16)
+
+
+def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
+    mocker: plugin.MockerFixture,
+    scan_message_ipv6_with_mask64: msg.Message,
+    virustotal_agent: virus_total_agent.VirusTotalAgent,
+) -> None:
+    """Test the CIDR Limit in case IPV6 and the Limit is reached."""
+    mocker.patch(
+        "agent.virustotal.scan_url_from_message",
+        return_value={},
+    )
+
+    with pytest.raises(ValueError, match="Subnet mask below 112 is not supported."):
+        virustotal_agent.process(scan_message_ipv6_with_mask64)
+
+
+def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+    mocker: plugin.MockerFixture,
+    scan_message_ipv6_with_mask112: msg.Message,
+    virustotal_agent: virus_total_agent.VirusTotalAgent,
+) -> None:
+    """Test the CIDR Limit in case IPV6 and the Limit is not reached."""
+    mocker.patch(
+        "agent.virustotal.scan_url_from_message",
+        return_value={},
+    )
+
+    virustotal_agent.process(scan_message_ipv6_with_mask112)

--- a/tests/virus_total_agent_test.py
+++ b/tests/virus_total_agent_test.py
@@ -381,3 +381,12 @@ def testVirusTotalAgent_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueErro
     )
 
     virustotal_agent.process(scan_message_ipv6_with_mask112)
+
+
+def testVirusTotalAgent_whenIPAssetHasIncorrectVersion_raiseValueError(
+    scan_message_ipv_with_incorrect_version: msg.Message,
+    virustotal_agent: virus_total_agent.VirusTotalAgent,
+) -> None:
+    """Test the CIDR Limit in case IP has incorrect version."""
+    with pytest.raises(ValueError, match="Incorrect ip version 5."):
+        virustotal_agent.process(scan_message_ipv_with_incorrect_version)

--- a/tests/virus_total_agent_test.py
+++ b/tests/virus_total_agent_test.py
@@ -337,22 +337,16 @@ def testVirusTotalAgent_whenFileHasNoPath_shouldReportWithHash(
     )
 
 
-def testPrepareTargets_whenIPv4AssetReachCIDRLimit_raiseValueError(
-    mocker: plugin.MockerFixture,
+def testVirusTotalAgent_whenIPv4AssetReachCIDRLimit_raiseValueError(
     scan_message_ipv4_with_mask8: msg.Message,
     virustotal_agent: virus_total_agent.VirusTotalAgent,
 ) -> None:
     """Test the CIDR Limit in case IPV4 and the Limit is reached."""
-    mocker.patch(
-        "agent.virustotal.scan_url_from_message",
-        return_value={},
-    )
-
     with pytest.raises(ValueError, match="Subnet mask below 16 is not supported."):
         virustotal_agent.process(scan_message_ipv4_with_mask8)
 
 
-def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+def testVirusTotalAgent_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
     mocker: plugin.MockerFixture,
     scan_message_ipv4_with_mask16: msg.Message,
     virustotal_agent: virus_total_agent.VirusTotalAgent,
@@ -366,22 +360,16 @@ def testPrepareTargets_whenIPv4AssetDoesNotReachCIDRLimit_doesNotRaiseValueError
     virustotal_agent.process(scan_message_ipv4_with_mask16)
 
 
-def testPrepareTargets_whenIPv6AssetReachCIDRLimit_raiseValueError(
-    mocker: plugin.MockerFixture,
+def testVirusTotalAgent_whenIPv6AssetReachCIDRLimit_raiseValueError(
     scan_message_ipv6_with_mask64: msg.Message,
     virustotal_agent: virus_total_agent.VirusTotalAgent,
 ) -> None:
     """Test the CIDR Limit in case IPV6 and the Limit is reached."""
-    mocker.patch(
-        "agent.virustotal.scan_url_from_message",
-        return_value={},
-    )
-
     with pytest.raises(ValueError, match="Subnet mask below 112 is not supported."):
         virustotal_agent.process(scan_message_ipv6_with_mask64)
 
 
-def testPrepareTargets_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
+def testVirusTotalAgent_whenIPv6AssetDoesNotReachCIDRLimit_doesNotRaiseValueError(
     mocker: plugin.MockerFixture,
     scan_message_ipv6_with_mask112: msg.Message,
     virustotal_agent: virus_total_agent.VirusTotalAgent,


### PR DESCRIPTION
**Enhancement Request: Set Maximum CIDR Prefix Length for Host Limitation**

**Description:**
In order to ensure controlled and efficient scanning, we propose enhancing the current configuration related to CIDR prefix length for IPv4 and IPv6 addresses.

```python
# Maximum CIDR prefix length to limit the number of hosts that can be scanned.
# For IPv4: Setting it to 16 (allowing for 2^(32-16) - 2 = 65,534 hosts).
# For IPv6: Setting it to 112 (allowing for 2^(128-112) = 65,536 hosts).
IPV4_CIDR_LIMIT = 16
IPV6_CIDR_LIMIT = 112
```

---