### PR TITLE
fix: remove codecov config

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -42,4 +42,3 @@ jobs:
     - name: Runnning tests with pytest.
       run: |
         pytest -m "not docker"
-    - name: Upload coverage to Codecov.

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -41,10 +41,5 @@ jobs:
         python -m uv pip install -r tests/test-requirements.txt
     - name: Runnning tests with pytest.
       run: |
-        pytest -m "not docker" --cov=./ --cov-report=xml:coverage.xml --cov-report=term-missing
+        pytest -m "not docker"
     - name: Upload coverage to Codecov.
-      uses: codecov/codecov-action@v4
-      with:
-        verbose: true
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: coverage.xml

--- a/agent/file.py
+++ b/agent/file.py
@@ -1,7 +1,5 @@
 """Collection of functions to handle files."""
 
-from typing import cast
-
 import requests
 import tenacity
 from ostorlab.agent.message import message as m
@@ -44,7 +42,7 @@ def get_file_content(message: m.Message) -> bytes | None:
     """
     content = message.data.get("content")
     if content is not None and isinstance(content, bytes):
-        return cast(bytes, content)
+        return content
     content_url: str | None = message.data.get("content_url")
     if content_url is not None:
         return _download_file(content_url)


### PR DESCRIPTION
Removes the codecov config file and the coverage upload from the pytest workflow.