### PR TITLE
feature: exclude paths

### DIFF
--- a/agent/common.py
+++ b/agent/common.py
@@ -3,6 +3,7 @@
 import ipaddress
 import json
 import logging
+import re
 from typing import cast, Any
 from urllib import parse
 
@@ -19,22 +20,27 @@ logger = logging.getLogger(__name__)
 
 
 def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
-    """Report whether a file path starts with one of the excluded prefixes.
+    """Report whether a file path matches one of the exclusion regex patterns.
 
     Args:
         path: The file path reported in the message, or None.
-        exclude_paths: List of path prefixes to match against the path.
+        exclude_paths: List of regex patterns to match against the path.
 
     Returns:
-        True if the path starts with at least one prefix and should be skipped,
+        True if the path matches at least one pattern and should be skipped,
         False otherwise.
     """
     if path is None or exclude_paths is None or len(exclude_paths) == 0:
         return False
-    for prefix in exclude_paths:
-        if path.startswith(prefix) is True:
+    for pattern in exclude_paths:
+        try:
+            matched = re.search(pattern, path)
+        except re.error as e:
+            logger.warning("Invalid exclude_paths regex %r: %s", pattern, e)
+            continue
+        if matched is not None:
             logger.info(
-                "Skipping file %s: path matches exclude prefix %r.", path, prefix
+                "Skipping file %s: path matches exclude pattern %r.", path, pattern
             )
             return True
     return False

--- a/agent/common.py
+++ b/agent/common.py
@@ -19,24 +19,26 @@ from ostorlab.agent.message import message as msg
 logger = logging.getLogger(__name__)
 
 
-def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
+def should_exclude_path(
+    path: str | None, exclude_path_regexes: list[str] | None
+) -> bool:
     """Report whether a file path matches one of the exclusion regex patterns.
 
     Args:
         path: The file path reported in the message, or None.
-        exclude_paths: List of regex patterns to match against the path.
+        exclude_path_regexes: List of regex patterns to match against the path.
 
     Returns:
         True if the path matches at least one pattern and should be skipped,
         False otherwise.
     """
-    if path is None or exclude_paths is None or len(exclude_paths) == 0:
+    if path is None or exclude_path_regexes is None or len(exclude_path_regexes) == 0:
         return False
-    for pattern in exclude_paths:
+    for pattern in exclude_path_regexes:
         try:
             matched = re.search(pattern, path)
         except re.error as e:
-            logger.warning("Invalid exclude_paths regex %r: %s", pattern, e)
+            logger.warning("Invalid exclude_path_regexes regex %r: %s", pattern, e)
             continue
         if matched is not None:
             logger.info(

--- a/agent/common.py
+++ b/agent/common.py
@@ -2,6 +2,7 @@
 
 import ipaddress
 import json
+import logging
 from typing import cast, Any
 from urllib import parse
 
@@ -13,6 +14,30 @@ from ostorlab.assets import ipv6 as ipv6_asset
 from ostorlab.assets import android_store as android_store_asset
 from ostorlab.assets import ios_store as ios_store_asset
 from ostorlab.agent.message import message as msg
+
+logger = logging.getLogger(__name__)
+
+
+def should_exclude_path(path: str | None, exclude_paths: list[str] | None) -> bool:
+    """Report whether a file path starts with one of the excluded prefixes.
+
+    Args:
+        path: The file path reported in the message, or None.
+        exclude_paths: List of path prefixes to match against the path.
+
+    Returns:
+        True if the path starts with at least one prefix and should be skipped,
+        False otherwise.
+    """
+    if path is None or exclude_paths is None or len(exclude_paths) == 0:
+        return False
+    for prefix in exclude_paths:
+        if path.startswith(prefix) is True:
+            logger.info(
+                "Skipping file %s: path matches exclude prefix %r.", path, prefix
+            )
+            return True
+    return False
 
 
 def prepare_host(host: str) -> str:

--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -69,6 +69,13 @@ class VirusTotalAgent(
         file_content = file.get_file_content(message)
         if file_content is not None:
             if (
+                common.should_exclude_path(
+                    message.data.get("path"), self.args.get("exclude_paths")
+                )
+                is True
+            ):
+                return None
+            if (
                 len(self.whitelist_types) != 0
                 and magic.from_buffer(file_content, mime=True)
                 not in self.whitelist_types

--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -69,7 +69,7 @@ class VirusTotalAgent(
         if (
             message.selector.startswith("v3.asset.file") is True
             and common.should_exclude_path(
-                message.data.get("path"), self.args.get("exclude_paths")
+                message.data.get("path"), self.args.get("exclude_path_regexes")
             )
             is True
         ):

--- a/agent/virus_total_agent.py
+++ b/agent/virus_total_agent.py
@@ -66,15 +66,17 @@ class VirusTotalAgent(
         Raises:
             NameError: In case the scans were not defined.
         """
+        if (
+            message.selector.startswith("v3.asset.file") is True
+            and common.should_exclude_path(
+                message.data.get("path"), self.args.get("exclude_paths")
+            )
+            is True
+        ):
+            return None
+
         file_content = file.get_file_content(message)
         if file_content is not None:
-            if (
-                common.should_exclude_path(
-                    message.data.get("path"), self.args.get("exclude_paths")
-                )
-                is True
-            ):
-                return None
             if (
                 len(self.whitelist_types) != 0
                 and magic.from_buffer(file_content, mime=True)

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -87,7 +87,7 @@ args:
   - name: "enable_whitelist"
     type: "array"
     description: "List of mimetypes types to whitelist for scanning."
-  - name: "exclude_paths"
+  - name: "exclude_path_regexes"
     type: "array"
     description: "List of regex patterns; files whose path matches any pattern are skipped."
 docker_file_path: Dockerfile

--- a/ostorlab.yaml
+++ b/ostorlab.yaml
@@ -87,5 +87,8 @@ args:
   - name: "enable_whitelist"
     type: "array"
     description: "List of mimetypes types to whitelist for scanning."
+  - name: "exclude_paths"
+    type: "array"
+    description: "List of regex patterns; files whose path matches any pattern are skipped."
 docker_file_path: Dockerfile
 docker_build_root: .

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -355,3 +355,12 @@ def testShouldExcludePath_whenRegexIsInvalid_shouldSkipPatternAndReturnFalse() -
     result = common.should_exclude_path("/workspace/a.py", ["[invalid("])
 
     assert result is False
+
+
+def testShouldExcludePath_whenInvalidRegexPrecedesValidMatch_shouldReturnTrue() -> None:
+    """An invalid pattern is skipped and a later valid pattern still matches."""
+    result = common.should_exclude_path(
+        "/workspace/a.py", ["[invalid(", r"^/workspace(/|$)"]
+    )
+
+    assert result is True

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -304,3 +304,54 @@ def testSortDict_always_returnsSortedDict(
 ) -> None:
     """Ensure sort_dict correctly sorts dictionary keys recursively."""
     assert common.sort_dict(unordered_dict) == expected
+
+
+def testShouldExcludePath_whenPathMatchesPattern_shouldReturnTrue() -> None:
+    """A path matching an exclude pattern returns True."""
+    result = common.should_exclude_path("/workspace/src/main.py", [r"^/workspace(/|$)"])
+
+    assert result is True
+
+
+def testShouldExcludePath_whenPathDoesNotMatch_shouldReturnFalse() -> None:
+    """A path not matching any pattern returns False."""
+    result = common.should_exclude_path("/tmp/main.py", [r"^/workspace(/|$)"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenSimilarPrefixNotUnderWorkspace_shouldReturnFalse() -> (
+    None
+):
+    """A lookalike path is not excluded by the anchored pattern."""
+    result = common.should_exclude_path("/workspace_backup/a.py", [r"^/workspace(/|$)"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenPathIsNone_shouldReturnFalse() -> None:
+    """A None path is never excluded."""
+    result = common.should_exclude_path(None, [r"^/workspace(/|$)"])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenExcludePathsIsEmpty_shouldReturnFalse() -> None:
+    """An empty pattern list excludes nothing."""
+    result = common.should_exclude_path("/workspace/a.py", [])
+
+    assert result is False
+
+
+def testShouldExcludePath_whenExcludePathsIsNone_shouldReturnFalse() -> None:
+    """A None pattern list excludes nothing."""
+    result = common.should_exclude_path("/workspace/a.py", None)
+
+    assert result is False
+
+
+def testShouldExcludePath_whenRegexIsInvalid_shouldSkipPatternAndReturnFalse() -> None:
+    """An invalid regex pattern is skipped instead of raising."""
+    result = common.should_exclude_path("/workspace/a.py", ["[invalid("])
+
+    assert result is False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,36 @@ def create_virustotal_agent(
         return agent
 
 
+@pytest.fixture(name="virustotal_agent_with_exclude_paths")
+def create_virustotal_agent_with_exclude_paths(
+    agent_mock: list[msg.Message],
+    agent_persist_mock: dict[str | bytes, str | bytes],
+) -> virus_total_agent.VirusTotalAgent:
+    """Instantiate a virustotal agent that excludes files under /workspace."""
+    del agent_mock, agent_persist_mock
+    with (pathlib.Path(__file__).parent.parent / "ostorlab.yaml").open() as yaml_o:
+        definition = agent_definitions.AgentDefinition.from_yaml(yaml_o)
+        definition.args = [
+            {
+                "name": "api_key",
+                "type": "string",
+                "value": "some_api_key",
+                "description": "Api key for the virus total API.",
+            },
+            {
+                "name": "exclude_paths",
+                "type": "array",
+                "value": [r"^/workspace(/|$)"],
+                "description": "List of regex patterns to skip by path.",
+            },
+        ]
+        settings = runtime_definitions.AgentSettings(
+            key="agent/ostorlab/agent_virustotal_key",
+            redis_url="redis://guest:guest@localhost:6379",
+        )
+        return virus_total_agent.VirusTotalAgent(definition, settings)
+
+
 @pytest.fixture
 def virustotal_agent_with_whitelist() -> virus_total_agent.VirusTotalAgent:
     """Instantiate a virustotal agent."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,8 +139,8 @@ def create_virustotal_agent(
         return agent
 
 
-@pytest.fixture(name="virustotal_agent_with_exclude_paths")
-def create_virustotal_agent_with_exclude_paths(
+@pytest.fixture(name="virustotal_agent_with_exclude_path_regexes")
+def create_virustotal_agent_with_exclude_path_regexes(
     agent_mock: list[msg.Message],
     agent_persist_mock: dict[str | bytes, str | bytes],
 ) -> virus_total_agent.VirusTotalAgent:
@@ -156,7 +156,7 @@ def create_virustotal_agent_with_exclude_paths(
                 "description": "Api key for the virus total API.",
             },
             {
-                "name": "exclude_paths",
+                "name": "exclude_path_regexes",
                 "type": "array",
                 "value": [r"^/workspace(/|$)"],
                 "description": "List of regex patterns to skip by path.",

--- a/tests/virus_total_agent_test.py
+++ b/tests/virus_total_agent_test.py
@@ -747,3 +747,21 @@ def testVirusTotalAgent_whenScannerIsExcluded_shouldNotBeConsidered(
         "android_store": {"package_name": "test.app.com"},
         "metadata": [{"type": "FILE_PATH", "value": ""}],
     }
+
+
+def testVirusTotalAgent_whenFilePathIsExcluded_notProcessMessage(
+    mocker: plugin.MockerFixture,
+    agent_mock: list[msg.Message],
+    virustotal_agent_with_exclude_paths: virus_total_agent.VirusTotalAgent,
+) -> None:
+    """A file whose path matches an exclude pattern is skipped: no scan, no emitted message."""
+    scan_mock = mocker.patch("agent.virustotal.scan_file_from_message")
+    message = msg.Message.from_data(
+        selector="v3.asset.file",
+        data={"content": b"some content", "path": "/workspace/file.bin"},
+    )
+
+    virustotal_agent_with_exclude_paths.process(message)
+
+    assert scan_mock.call_count == 0
+    assert len(agent_mock) == 0

--- a/tests/virus_total_agent_test.py
+++ b/tests/virus_total_agent_test.py
@@ -765,3 +765,26 @@ def testVirusTotalAgent_whenFilePathIsExcluded_notProcessMessage(
 
     assert scan_mock.call_count == 0
     assert len(agent_mock) == 0
+
+
+def testVirusTotalAgent_whenFilePathIsNotExcluded_processMessage(
+    mocker: plugin.MockerFixture,
+    agent_mock: list[msg.Message],
+    virustotal_agent_with_exclude_paths: virus_total_agent.VirusTotalAgent,
+) -> None:
+    """A file whose path does not match any exclude pattern is scanned normally."""
+    scan_mock = mocker.patch(
+        "agent.virustotal.scan_file_from_message", return_value={}
+    )
+    process_response_mock = mocker.patch.object(
+        virustotal_agent_with_exclude_paths, "_process_response"
+    )
+    message = msg.Message.from_data(
+        selector="v3.asset.file",
+        data={"content": b"some content", "path": "/tmp/file.bin"},
+    )
+
+    virustotal_agent_with_exclude_paths.process(message)
+
+    assert scan_mock.call_count == 1
+    assert process_response_mock.call_count == 1

--- a/tests/virus_total_agent_test.py
+++ b/tests/virus_total_agent_test.py
@@ -752,7 +752,7 @@ def testVirusTotalAgent_whenScannerIsExcluded_shouldNotBeConsidered(
 def testVirusTotalAgent_whenFilePathIsExcluded_notProcessMessage(
     mocker: plugin.MockerFixture,
     agent_mock: list[msg.Message],
-    virustotal_agent_with_exclude_paths: virus_total_agent.VirusTotalAgent,
+    virustotal_agent_with_exclude_path_regexes: virus_total_agent.VirusTotalAgent,
 ) -> None:
     """A file whose path matches an exclude pattern is skipped: no scan, no emitted message."""
     scan_mock = mocker.patch("agent.virustotal.scan_file_from_message")
@@ -761,7 +761,7 @@ def testVirusTotalAgent_whenFilePathIsExcluded_notProcessMessage(
         data={"content": b"some content", "path": "/workspace/file.bin"},
     )
 
-    virustotal_agent_with_exclude_paths.process(message)
+    virustotal_agent_with_exclude_path_regexes.process(message)
 
     assert scan_mock.call_count == 0
     assert len(agent_mock) == 0
@@ -770,19 +770,19 @@ def testVirusTotalAgent_whenFilePathIsExcluded_notProcessMessage(
 def testVirusTotalAgent_whenFilePathIsNotExcluded_processMessage(
     mocker: plugin.MockerFixture,
     agent_mock: list[msg.Message],
-    virustotal_agent_with_exclude_paths: virus_total_agent.VirusTotalAgent,
+    virustotal_agent_with_exclude_path_regexes: virus_total_agent.VirusTotalAgent,
 ) -> None:
-    """A file whose path does not match any exclude pattern is scanned normally."""
-    scan_mock = mocker.patch("agent.virustotal.scan_file_from_message", return_value={})
-    process_response_mock = mocker.patch.object(
-        virustotal_agent_with_exclude_paths, "_process_response"
+    """A file whose path does not match any exclude pattern is scanned and reported."""
+    mocker.patch(
+        "virus_total_apis.PublicApi.get_file_report",
+        side_effect=virustotal_valid_response,
     )
     message = msg.Message.from_data(
         selector="v3.asset.file",
         data={"content": b"some content", "path": "/tmp/file.bin"},
     )
 
-    virustotal_agent_with_exclude_paths.process(message)
+    virustotal_agent_with_exclude_path_regexes.process(message)
 
-    assert scan_mock.call_count == 1
-    assert process_response_mock.call_count == 1
+    assert len(agent_mock) == 1
+    assert agent_mock[0].selector == "v3.report.vulnerability"

--- a/tests/virus_total_agent_test.py
+++ b/tests/virus_total_agent_test.py
@@ -773,9 +773,7 @@ def testVirusTotalAgent_whenFilePathIsNotExcluded_processMessage(
     virustotal_agent_with_exclude_paths: virus_total_agent.VirusTotalAgent,
 ) -> None:
     """A file whose path does not match any exclude pattern is scanned normally."""
-    scan_mock = mocker.patch(
-        "agent.virustotal.scan_file_from_message", return_value={}
-    )
+    scan_mock = mocker.patch("agent.virustotal.scan_file_from_message", return_value={})
     process_response_mock = mocker.patch.object(
         virustotal_agent_with_exclude_paths, "_process_response"
     )


### PR DESCRIPTION
# Add exclude_path_regexes arg to skip files by regex pattern

Adds a new `exclude_path_regexes` arg (list of regex patterns). When a `v3.asset.file` message has a path that matches one of the patterns, the agent logs and skips the file instead of scanning it.

- New `exclude_path_regexes` arg in `ostorlab.yaml`.
- File processing skips any path matching an excluded pattern.
